### PR TITLE
Journal: add entry

### DIFF
--- a/ProjectCaterpillar/Controllers/JournalAddEntryViewController.swift
+++ b/ProjectCaterpillar/Controllers/JournalAddEntryViewController.swift
@@ -17,6 +17,7 @@ class JournalAddEntryViewController: UITableViewController {
     
     // MARK: - Properties
     weak var delegate: JournalAddEntryViewControllerDelegate?
+    var newEntry: JournalEntry?
     
     // MARK: - Outlets
     @IBOutlet weak var titleField: UITextField!
@@ -32,11 +33,12 @@ class JournalAddEntryViewController: UITableViewController {
     let lifeStages = ["Egg", "Caterpillar", "Butterfly"]
     
     @IBAction func save() {
-        
+        guard let entry = newEntry else { return }
+        delegate?.add(self, didFinishAdding: entry)
     }
     
     @IBAction func cancel() {
-        
+        delegate?.addDidCancel(self)
     }
 }
 

--- a/ProjectCaterpillar/Controllers/JournalAddEntryViewController.swift
+++ b/ProjectCaterpillar/Controllers/JournalAddEntryViewController.swift
@@ -8,8 +8,15 @@
 
 import UIKit
 
+protocol JournalAddEntryViewControllerDelegate: class {
+    func addDidCancel(_ controller: JournalAddEntryViewController)
+    func add(_ controller: JournalAddEntryViewController, didFinishAdding item: JournalEntry)
+}
+
 class JournalAddEntryViewController: UITableViewController {
     
+    // MARK: - Properties
+    weak var delegate: JournalAddEntryViewControllerDelegate?
     
     // MARK: - Outlets
     @IBOutlet weak var titleField: UITextField!
@@ -23,6 +30,14 @@ class JournalAddEntryViewController: UITableViewController {
     }
 
     let lifeStages = ["Egg", "Caterpillar", "Butterfly"]
+    
+    @IBAction func save() {
+        
+    }
+    
+    @IBAction func cancel() {
+        
+    }
 }
 
 extension JournalAddEntryViewController: UIPickerViewDataSource, UIPickerViewDelegate {

--- a/ProjectCaterpillar/Controllers/JournalAddEntryViewController.swift
+++ b/ProjectCaterpillar/Controllers/JournalAddEntryViewController.swift
@@ -23,22 +23,30 @@ class JournalAddEntryViewController: UITableViewController {
     @IBOutlet weak var titleField: UITextField!
     @IBOutlet weak var dateField: UITextField!
     @IBOutlet weak var lifestagePicker: UIPickerView!
+    @IBOutlet weak var detailsView: UITextView!
     
+    // MARK: - Methods
     override func viewDidLoad() {
         super.viewDidLoad()
         lifestagePicker.dataSource = self
         lifestagePicker.delegate = self
     }
 
+    // temporary lifestage data, replace w/ real lifestages from database
     let lifeStages = ["Egg", "Caterpillar", "Butterfly"]
     
     @IBAction func save() {
-        guard let entry = newEntry else { return }
+        let entry = createNewEntry()
         delegate?.add(self, didFinishAdding: entry)
     }
     
     @IBAction func cancel() {
         delegate?.addDidCancel(self)
+    }
+    
+    func createNewEntry() -> JournalEntry {
+        newEntry = JournalEntry(title: titleField.text!, stageOfLife: egg, details: detailsView.text!, date: dateField.text!)
+        return newEntry!
     }
 }
 

--- a/ProjectCaterpillar/Controllers/JournalListViewController.swift
+++ b/ProjectCaterpillar/Controllers/JournalListViewController.swift
@@ -68,3 +68,19 @@ class JournalListViewController: UITableViewController {
     */
 
 }
+
+extension JournalListViewController: JournalAddEntryViewControllerDelegate {
+    func addDidCancel(_ controller: JournalAddEntryViewController) {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    func add(_ controller: JournalAddEntryViewController, didFinishAdding item: JournalEntry) {
+        let newRowIndex = journalEntries.count
+        journalEntries.append(item)
+        
+        let indexPath = IndexPath(row: newRowIndex, section: 0)
+        tableView.insertRows(at: [indexPath], with: .automatic)
+        
+        navigationController?.popViewController(animated: true)
+    }
+}

--- a/ProjectCaterpillar/Controllers/JournalListViewController.swift
+++ b/ProjectCaterpillar/Controllers/JournalListViewController.swift
@@ -57,18 +57,18 @@ class JournalListViewController: UITableViewController {
         }
     }
 
-    /*
     // MARK: - Navigation
 
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+        if segue.identifier == "JournalToAddEntry" {
+            guard let add = segue.destination as? JournalAddEntryViewController else { return }
+            add.delegate = self
+        }
     }
-    */
 
 }
 
+// MARK: - JournalAddEntryViewControllerDelegate Protocol
 extension JournalListViewController: JournalAddEntryViewControllerDelegate {
     func addDidCancel(_ controller: JournalAddEntryViewController) {
         navigationController?.popViewController(animated: true)

--- a/ProjectCaterpillar/Storyboards/Journal.storyboard
+++ b/ProjectCaterpillar/Storyboards/Journal.storyboard
@@ -38,7 +38,7 @@
                     <navigationItem key="navigationItem" title="Journal 🥚🐛🦋" id="BKG-X9-ZYs">
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="Z2D-ox-N0Z">
                             <connections>
-                                <segue destination="h2G-nf-EVn" kind="show" id="gEM-mF-FaW"/>
+                                <segue destination="h2G-nf-EVn" kind="show" identifier="JournalToAddEntry" id="gEM-mF-FaW"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -295,6 +295,7 @@
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="dateField" destination="gHs-7n-3ZH" id="iRj-16-Wck"/>
+                        <outlet property="detailsView" destination="SvP-8X-O4n" id="tzs-EZ-ZNW"/>
                         <outlet property="lifestagePicker" destination="rlV-sI-XA4" id="VkN-3x-nyX"/>
                         <outlet property="titleField" destination="foX-d5-cm4" id="Gge-fp-ncQ"/>
                     </connections>

--- a/ProjectCaterpillar/Storyboards/Journal.storyboard
+++ b/ProjectCaterpillar/Storyboards/Journal.storyboard
@@ -281,8 +281,16 @@
                     </tableView>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" title="Add Entry" id="M7T-7f-U8u">
-                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="nbx-03-EBj"/>
-                        <barButtonItem key="rightBarButtonItem" style="done" systemItem="save" id="FkJ-4o-MyN"/>
+                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="nbx-03-EBj">
+                            <connections>
+                                <action selector="cancel" destination="h2G-nf-EVn" id="feo-v5-1DH"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" style="done" systemItem="save" id="FkJ-4o-MyN">
+                            <connections>
+                                <action selector="save" destination="h2G-nf-EVn" id="nLw-sO-mMQ"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>

--- a/ProjectCaterpillar/Storyboards/Journal.storyboard
+++ b/ProjectCaterpillar/Storyboards/Journal.storyboard
@@ -38,7 +38,7 @@
                     <navigationItem key="navigationItem" title="Journal 🥚🐛🦋" id="BKG-X9-ZYs">
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="Z2D-ox-N0Z">
                             <connections>
-                                <segue destination="h2G-nf-EVn" kind="show" id="59J-8l-woj"/>
+                                <segue destination="h2G-nf-EVn" kind="show" id="gEM-mF-FaW"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>


### PR DESCRIPTION
## Reason
Trello Card: [Journal: Ability to Add Entry](https://trello.com/c/qiREo1lI)

Give user ability to add new journal entries (woohoo!).

## What I did
Saved user text into a `newEntry` JournalEntry variable, and passed that back to the overview list of journal entries.

## How I did it
Used everybody's favorite thing, delegates! 

## How you can test it
- Run the app on your machine and head to the Journal section.
- Tap the + to go to Add Entry screen.
- Type and add a title, date, & details. (You can also pick a life stage but that doesn't get saved just yet.)
- Tap "Save."
- See your new entry on the list of journal entries!
- **Note**: When you tap your entry you won't see the right details, just sample details for now. That's up next!

## Screenshots
![simulator screen shot - iphone x - 2018-09-19 at 15 19 54](https://user-images.githubusercontent.com/5642098/45776030-a56a1100-bc1f-11e8-96ea-8989c4ecc856.png)
![simulator screen shot - iphone x - 2018-09-19 at 15 20 00](https://user-images.githubusercontent.com/5642098/45776032-a733d480-bc1f-11e8-9469-bd8c923999ef.png)
