### PR TITLE
Journal: Ability to edit entry

### DIFF
--- a/ProjectCaterpillar/Controllers/JournalDetailViewController.swift
+++ b/ProjectCaterpillar/Controllers/JournalDetailViewController.swift
@@ -82,6 +82,7 @@ class JournalDetailViewController: UITableViewController {
     }
     
     @IBAction func editButton(_ sender: Any) {
+        titleField.becomeFirstResponder()
         toggleEditItems()
         toggleLabelVisibility()
     }

--- a/ProjectCaterpillar/Controllers/JournalDetailViewController.swift
+++ b/ProjectCaterpillar/Controllers/JournalDetailViewController.swift
@@ -8,8 +8,16 @@
 
 import UIKit
 
+protocol JournalDetailViewControllerDelegate: class {
+    func detailVC(_ controller: JournalDetailViewController, didFinishEditing item: JournalEntry)
+}
+
 class JournalDetailViewController: UITableViewController {
+    
+    // MARK: - Properties
     let lifeStages = ["Egg", "Caterpillar", "Butterfly"]
+    weak var delegate: JournalDetailViewControllerDelegate?
+    var entryToShow: JournalEntry?
     
     // MARK: - Outlets
     @IBOutlet weak var titleLabel: UILabel!
@@ -22,8 +30,7 @@ class JournalDetailViewController: UITableViewController {
     @IBOutlet weak var dateField: UITextField!
     @IBOutlet weak var lifestagePicker: UIPickerView!
     
-    // dummy data to use for now - remove when we start passing in real data:
-    var entry1 = JournalEntry(title: "Example Entry", stageOfLife: egg, details: "Found this egg and it's sweet", date: "Sep 18 2018")
+   
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,15 +42,17 @@ class JournalDetailViewController: UITableViewController {
     }
     
     func displayEntryData() {
-        titleLabel.text = entry1.title
-        dateLabel.text = entry1.date
-        lifestageLabel.text = entry1.stageOfLife.name
-        detailsView.text = entry1.details
+        guard let entry = entryToShow else { return }
+        titleLabel.text = entry.title
+        dateLabel.text = entry.date
+        lifestageLabel.text = entry.stageOfLife.name
+        detailsView.text = entry.details
     }
     
     func populateTextFields() {
-        titleField.text = entry1.title
-        dateField.text = entry1.date
+        guard let entry = entryToShow else { titleField.text = ""; dateField.text = "" ; return }
+        titleField.text = entry.title
+        dateField.text = entry.date
     }
     
     func enableLifestagePicker() {

--- a/ProjectCaterpillar/Controllers/JournalDetailViewController.swift
+++ b/ProjectCaterpillar/Controllers/JournalDetailViewController.swift
@@ -23,22 +23,18 @@ class JournalDetailViewController: UITableViewController {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var dateLabel: UILabel!
     @IBOutlet weak var lifestageLabel: UILabel!
-    
     @IBOutlet weak var detailsView: UITextView!
-    
     @IBOutlet weak var titleField: UITextField!
     @IBOutlet weak var dateField: UITextField!
     @IBOutlet weak var lifestagePicker: UIPickerView!
-    
-   
+    @IBOutlet weak var saveBarButton: UIBarButtonItem!
 
     override func viewDidLoad() {
         super.viewDidLoad()
         displayEntryData()
         populateTextFields()
         enableLifestagePicker()
-        toggleFieldVisibility()
-        togglePickerVisibility()
+        toggleEditItems()
     }
     
     func displayEntryData() {
@@ -75,10 +71,34 @@ class JournalDetailViewController: UITableViewController {
         lifestagePicker.isHidden = !lifestagePicker.isHidden
     }
     
-    @IBAction func editButton(_ sender: Any) {
+    func toggleSaveButtonIsEnabled() {
+        saveBarButton.isEnabled = !saveBarButton.isEnabled
+    }
+    
+    func toggleEditItems() {
         toggleFieldVisibility()
-        toggleLabelVisibility()
         togglePickerVisibility()
+        toggleSaveButtonIsEnabled()
+    }
+    
+    @IBAction func editButton(_ sender: Any) {
+        toggleEditItems()
+        toggleLabelVisibility()
+    }
+    
+    @IBAction func save(_ sender: UIBarButtonItem) {
+        guard let entryToUpdate = entryToShow else { return }
+        
+        guard let updatedTitle = titleField.text else { return }
+        entryToUpdate.title = updatedTitle
+        
+        guard let updatedDate = dateField.text else { return }
+        entryToUpdate.date = updatedDate
+        
+        guard let updatedDetails = detailsView.text else { return }
+        entryToUpdate.details = updatedDetails
+        
+        delegate?.detailVC(self, didFinishEditing: entryToUpdate)
     }
 }
 

--- a/ProjectCaterpillar/Controllers/JournalListViewController.swift
+++ b/ProjectCaterpillar/Controllers/JournalListViewController.swift
@@ -12,6 +12,7 @@ class JournalListViewController: UITableViewController {
     
     // MARK: - Temporary Data
     var journalEntries: [JournalEntry] = []
+    var selectedEntryIndex = 0
     
     var entry1 = JournalEntry(title: "Example Entry", stageOfLife: egg, details: "Found this egg and it's sweet", date: "Sep 18 2018")
     var entry2 = JournalEntry(title: "Another Entry", stageOfLife: caterpillar, details: "Aww it hatched", date: "Sep 20 2018")
@@ -51,6 +52,11 @@ class JournalListViewController: UITableViewController {
         return cell
     }
     
+    override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        selectedEntryIndex = indexPath.row
+        return indexPath
+    }
+    
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
             swipeToDelete(indexPath: indexPath)
@@ -63,6 +69,11 @@ class JournalListViewController: UITableViewController {
         if segue.identifier == "JournalToAddEntry" {
             guard let add = segue.destination as? JournalAddEntryViewController else { return }
             add.delegate = self
+        }
+        else if segue.identifier == "JournalListToDetail" {
+            guard let detail = segue.destination as? JournalDetailViewController else { return }
+            detail.entryToShow = journalEntries[selectedEntryIndex]
+            detail.delegate = self
         }
     }
 
@@ -81,6 +92,18 @@ extension JournalListViewController: JournalAddEntryViewControllerDelegate {
         let indexPath = IndexPath(row: newRowIndex, section: 0)
         tableView.insertRows(at: [indexPath], with: .automatic)
         
+        navigationController?.popViewController(animated: true)
+    }
+}
+
+// MARK: - JournalDetailViewControllerDelegate Protocol
+extension JournalListViewController: JournalDetailViewControllerDelegate {
+    func detailVC(_ controller: JournalDetailViewController, didFinishEditing item: JournalEntry) {
+        guard let index = self.journalEntries.index(of: item) else { return }
+        let indexPath = IndexPath(row: index, section: 0)
+        
+        guard let cell = tableView.cellForRow(at: indexPath) else { return }
+        cell.textLabel?.text = item.title
         navigationController?.popViewController(animated: true)
     }
 }

--- a/ProjectCaterpillar/Storyboards/Journal.storyboard
+++ b/ProjectCaterpillar/Storyboards/Journal.storyboard
@@ -26,7 +26,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                                 <connections>
-                                    <segue destination="WMM-gs-vm4" kind="show" id="d1N-zc-LZz"/>
+                                    <segue destination="WMM-gs-vm4" kind="show" identifier="JournalListToDetail" id="d1N-zc-LZz"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/ProjectCaterpillar/Storyboards/Journal.storyboard
+++ b/ProjectCaterpillar/Storyboards/Journal.storyboard
@@ -160,12 +160,20 @@
                             <outlet property="delegate" destination="WMM-gs-vm4" id="e9e-tJ-a9A"/>
                         </connections>
                     </tableView>
+                    <navigationItem key="navigationItem" title="Title" id="ui3-0m-Piu">
+                        <barButtonItem key="rightBarButtonItem" style="done" systemItem="save" id="VA1-Un-tfq">
+                            <connections>
+                                <action selector="save:" destination="WMM-gs-vm4" id="YIN-bf-xTy"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="dateField" destination="HRf-II-pPX" id="YBz-YD-eBK"/>
                         <outlet property="dateLabel" destination="rMD-Bb-VQG" id="4cc-x4-7HI"/>
                         <outlet property="detailsView" destination="P6P-3V-vGd" id="0e3-Wz-XfZ"/>
                         <outlet property="lifestageLabel" destination="BBX-Aw-1TD" id="dfY-Px-oaj"/>
                         <outlet property="lifestagePicker" destination="7KT-HZ-7U5" id="wiM-ym-hir"/>
+                        <outlet property="saveBarButton" destination="VA1-Un-tfq" id="fRa-97-PNL"/>
                         <outlet property="titleField" destination="tvG-Xq-Gff" id="SIH-T3-1rU"/>
                         <outlet property="titleLabel" destination="XsO-9Q-DD4" id="F8A-br-GXE"/>
                     </connections>


### PR DESCRIPTION
## Reason
Trello Card: [Journal: Ability to Edit Entry](https://trello.com/c/x90eRO0R)

Give the user the ability to edit an existing journal entry.

## What I did
- Tapping on an entry on the main Journal screen now takes you to the right details
- Editing an entry passes the edits back to the main screen

## How I did it
- Passed the tapped entry index to the detail view, and loaded the proper details.
- Saved user edits (from text fields) to the entry. 
- Passed edited entry data back to main journal screen using delegation.

**Note**: The picker in the edit screen doesn't 100% work yet. That's another card, coming soon. :)

## How you can test it
- Tap on a journal in the journal entry list. You should see the details of the entry you've tapped.
- Tap the "Edit" button at the bottom of the screen.
- Edit your title, date, or details and tap "Save."
- Tap on your edited entry and verify that your changes are still in place.

## Screenshots
![simulator screen shot - iphone x - 2018-09-20 at 13 47 13](https://user-images.githubusercontent.com/5642098/45836775-b8421b80-bcdb-11e8-9719-d8844fbbfc4c.png)
![simulator screen shot - iphone x - 2018-09-20 at 13 47 18](https://user-images.githubusercontent.com/5642098/45836776-b8421b80-bcdb-11e8-8972-6aa5d6aae8d4.png)