### PR TITLE
Update user info home

### DIFF
--- a/ProjectCaterpillar/Controllers/HomeViewController.swift
+++ b/ProjectCaterpillar/Controllers/HomeViewController.swift
@@ -31,6 +31,10 @@ class HomeViewController: UIViewController, UIPickerViewDataSource, UIPickerView
      
     }
     
+    @IBOutlet weak var updateUserButtonOutlet: UIButton!
+    @IBAction func updateUserInfoButton(_ sender: UIButton) {
+        toggleDisplayData()
+    }
     @IBOutlet weak var userDisplayLabel: UILabel!
     @IBOutlet weak var petNameLabel: UILabel!
     
@@ -51,8 +55,6 @@ class HomeViewController: UIViewController, UIPickerViewDataSource, UIPickerView
         guard let userPetIcon = pet?.stageOfLife.iconFile else { return "Butterfly" }
     return userPetIcon
     }
-    
-    
     
     @IBOutlet weak var addButtonOutlet: UIButton!
     
@@ -128,6 +130,7 @@ class HomeViewController: UIViewController, UIPickerViewDataSource, UIPickerView
         } else {
             userNameTextField.becomeFirstResponder()
             loadImage(image: userPetIcon)
+            updateUserButtonOutlet.isHidden = true
             nameDisplayLabel.isHidden = true
             petNameDisplayLabel.isHidden = true
             infoDisplayLabel.isHidden = true

--- a/ProjectCaterpillar/Controllers/HomeViewController.swift
+++ b/ProjectCaterpillar/Controllers/HomeViewController.swift
@@ -91,7 +91,7 @@ class HomeViewController: UIViewController, UIPickerViewDataSource, UIPickerView
         petNameLabel.isHidden = true
         lifeStagePickerDisplayLabel.isHidden = true
         nameDisplayLabel.text = "Welcome \(user!.name)!"
-        petNameDisplayLabel.text = "Your pet \(pet!.name) is the \(pet!.stageOfLife.name)!" 
+        petNameDisplayLabel.text = "Your pet \(pet!.name) is in the \(pet!.stageOfLife.name)!" 
         addButtonOutlet.isHidden = true
         infoDisplayLabel.isHidden = false
         infoDisplayLabel.text = "Click the lifestages tab below to learn more about your new pet, or check out the journal to keep track of your pet’s progress! \n\nToday's Date: \(formattedDate())"

--- a/ProjectCaterpillar/Controllers/HomeViewController.swift
+++ b/ProjectCaterpillar/Controllers/HomeViewController.swift
@@ -33,7 +33,8 @@ class HomeViewController: UIViewController, UIPickerViewDataSource, UIPickerView
     
     @IBOutlet weak var updateUserButtonOutlet: UIButton!
     @IBAction func updateUserInfoButton(_ sender: UIButton) {
-        toggleDisplayData()
+//        toggleDisplayData()
+        updateUserData()
     }
     @IBOutlet weak var userDisplayLabel: UILabel!
     @IBOutlet weak var petNameLabel: UILabel!
@@ -83,6 +84,23 @@ class HomeViewController: UIViewController, UIPickerViewDataSource, UIPickerView
         }
     }
     
+    func updateUserData() {
+//        updatePetIcon()
+        infoDisplayLabel.isHidden = true
+        updateUserButtonOutlet.isHidden = true
+        addButtonOutlet.isHidden = false
+        petNameDisplayLabel.isHidden = true
+        nameDisplayLabel.isHidden = true
+        lifeStagePickerDisplayLabel.isHidden = false
+        petNameLabel.isHidden = false
+        petNameDisplayLabel.isHidden = true
+        nameDisplayLabel.isHidden = true
+        petNameTextField.isHidden = false
+        userDisplayLabel.isHidden = false
+        userNameTextField.isHidden = false
+        lifeStagePicker.isHidden = false
+    }
+    
     func toggleDisplayData() {
         lifeStagePicker.isHidden = true
         userNameTextField.isHidden = true
@@ -95,6 +113,7 @@ class HomeViewController: UIViewController, UIPickerViewDataSource, UIPickerView
         nameDisplayLabel.text = "Welcome \(user!.name)!"
         petNameDisplayLabel.text = "Your pet \(pet!.name) is in the \(pet!.stageOfLife.name)!" 
         addButtonOutlet.isHidden = true
+        updateUserButtonOutlet.isHidden = false
         infoDisplayLabel.isHidden = false
         infoDisplayLabel.text = "Click the lifestages tab below to learn more about your new pet, or check out the journal to keep track of your pet’s progress! \n\nToday's Date: \(formattedDate())"
 
@@ -122,6 +141,7 @@ class HomeViewController: UIViewController, UIPickerViewDataSource, UIPickerView
         super.viewDidLoad()
         let checkForFile = checkForLoadFile()
         populateLifeStage()
+        print(dataFilePath())
 
         if checkForFile {
             load()

--- a/ProjectCaterpillar/Model/LifestagesDatabase.swift
+++ b/ProjectCaterpillar/Model/LifestagesDatabase.swift
@@ -30,7 +30,7 @@ struct LifestagesDatabase {
                                    imgFile: "lifestage3",
                                    bulletPoints: ["Inside the chysalis the real action is happening called metamorphosis!", "Tissue, limbs and organs of a caterpillar have all been changed by the time the pupa is finished, and is now ready for the final stage of a butterfly’s life cycle."], iconFile: "chrysalis"),
     
-                    LifeStage(name: "Adult Butterfly",
+                    LifeStage(name: "Butterfly Stage",
                                    food: "All the leaves!",
                                    stageDescription: "When the butterfly first emerges from the chrysalis, both of the wings are going to be soft and folded against its body. This is because the butterfly had to fit all its new parts inside of the pupa.",
                                    imgFile: "lifestage4",

--- a/ProjectCaterpillar/Storyboards/Home.storyboard
+++ b/ProjectCaterpillar/Storyboards/Home.storyboard
@@ -106,6 +106,18 @@
                                 <color key="textColor" red="0.3294117647" green="0.4941176471" blue="0.16862745100000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="67G-8R-KSS">
+                                <rect key="frame" x="132" y="539" width="111" height="46"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" red="0.3294117647" green="0.4941176471" blue="0.16862745100000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <fontDescription key="fontDescription" name="DINAlternate-Bold" family="DIN Alternate" pointSize="12"/>
+                                <state key="normal" title="Update User Info">
+                                    <color key="titleColor" name="alternateSelectedControlTextColor" catalog="System" colorSpace="catalog"/>
+                                </state>
+                                <connections>
+                                    <action selector="updateUserInfoButton:" destination="VFQ-pp-NI6" eventType="touchUpInside" id="dZm-h1-0Qp"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="0.9882352941176471" green="0.9882352941176471" blue="0.9882352941176471" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="jVe-jt-5M9"/>
@@ -121,6 +133,7 @@
                         <outlet property="petNameDisplayLabel" destination="WoS-BK-sUI" id="o7v-OX-DYh"/>
                         <outlet property="petNameLabel" destination="cC0-Au-Voq" id="ZE0-7l-GIk"/>
                         <outlet property="petNameTextField" destination="dzw-aO-vHE" id="Ea3-sB-A4H"/>
+                        <outlet property="updateUserButtonOutlet" destination="67G-8R-KSS" id="u7Y-kS-VC0"/>
                         <outlet property="userDisplayLabel" destination="nBu-GV-jNA" id="bbZ-oy-xhw"/>
                         <outlet property="userNameTextField" destination="XWG-Ix-mez" id="Ezr-jg-Ylj"/>
                     </connections>


### PR DESCRIPTION
## Reason
Trello Card: Home: update user info + lifecycle

## What I did
After a user enters their name, the pet's name, and the pet's lifestage and clicks "add", you are sent to the user over view screen. I added a button called "update user info"
Once selected, the text fields come back, and the life stage picked returns. Mainly used to update the pet's lifestage, so be careful editing because if you remove your name or the pet's name, that will update as well. 

## How you can test it
Enter user info, click add, then select "Update User Info" button.

## Screenshots

<img width="411" alt="screen shot 2018-09-20 at 3 12 50 pm" src="https://user-images.githubusercontent.com/42354785/45841465-ecbbd480-bce7-11e8-8cdc-c4d3ccbfa96d.png">
<img width="403" alt="screen shot 2018-09-20 at 3 12 27 pm" src="https://user-images.githubusercontent.com/42354785/45841467-ed546b00-bce7-11e8-8bc5-3092c1e2ee95.png">
<img width="405" alt="screen shot 2018-09-20 at 3 12 40 pm" src="https://user-images.githubusercontent.com/42354785/45841469-ed546b00-bce7-11e8-9c90-1e3eddbfb9d1.png">
