### PR TITLE
moved update user info button to bottom center

### DIFF
--- a/ProjectCaterpillar/Storyboards/Home.storyboard
+++ b/ProjectCaterpillar/Storyboards/Home.storyboard
@@ -119,9 +119,9 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="67G-8R-KSS">
-                                <rect key="frame" x="264" y="98" width="111" height="46"/>
+                                <rect key="frame" x="133" y="663" width="111" height="46"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" name="DINAlternate-Bold" family="DIN Alternate" pointSize="12"/>
+                                <fontDescription key="fontDescription" name="DINAlternate-Bold" family="DIN Alternate" pointSize="14"/>
                                 <state key="normal" title="Update User Info">
                                     <color key="titleColor" red="0.3294117647" green="0.4941176471" blue="0.16862745100000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>


### PR DESCRIPTION
**What I did:**
Moved Update User Info button from top-right to bottom-center.

**WHY**
The button looked wonky and disjointed in the top-right corner. It flows better toward the bottom of the screen, keeping in line with the other elements on the screen.

<img width="314" alt="screen shot 2018-09-21 at 1 23 13 pm" src="https://user-images.githubusercontent.com/37513899/45896222-72e82180-bda1-11e8-957e-a641e86bb690.png">
